### PR TITLE
Expose the generated breaking changes as step#outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
     default: ${{ github.token }}
   buf_token:
     description: "The buf authentication token used for private inputs."
+outputs:
+  results:
+    description: "The generated breaking change messages with the file annotations."
 runs:
   using: "node12"
   main: "./dist/main.js"

--- a/src/run.ts
+++ b/src/run.ts
@@ -130,6 +130,9 @@ async function runBreaking(): Promise<null|Error> {
     if (isError(result)) {
         return result
     }
+
+    core.setOutput('results', result.fileAnnotations)
+
     if (result.fileAnnotations.length === 0) {
         core.info('No breaking errors were found.');
         return null;


### PR DESCRIPTION
Thank you for providing this amazing action. 

This pr exposes the generated file annotation entities as the steps's outputs because we'd like to allow following steps to use these entities. It looks redundant to re-run the checker and your file annotation's information is very useful.