### PR TITLE
Test action in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.22
       - name: Install Node
@@ -28,3 +28,9 @@ jobs:
         run: make generate && make checkgenerate
       - name: Build
         run: make build && make checkgenerate
+      - uses: bufbuild/buf-setup-action@v1.29.0-1
+      - run: |
+          echo "version: v1" >> buf.yaml
+          echo 'syntax = "proto3"; message A { string a = 1; }' >> test.proto
+      - name: Validate Action
+        uses: ./

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,10 @@ jobs:
         run: make generate && make checkgenerate
       - name: Build
         run: make build && make checkgenerate
-      - uses: bufbuild/buf-setup-action@v1.29.0-1
-      - run: |
+      - name: Install Buf
+        uses: bufbuild/buf-setup-action@v1
+      - name: Setup Test
+        run: |
           echo "version: v1" >> buf.yaml
           echo 'syntax = "proto3"; message A { string a = 1; }' >> test.proto
       - name: Validate Action

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,3 +34,5 @@ jobs:
           echo 'syntax = "proto3"; message A { string a = 1; }' >> test.proto
       - name: Validate Action
         uses: ./
+        with:
+          against: .

--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ outputs:
   results:
     description: "The generated breaking change messages with the file annotations."
 runs:
-  using: "node16"
+  using: "node20"
   main: "./dist/main.js"


### PR DESCRIPTION
This PR ensures CI runs the action built from this commit. We generate a dummy proto file to check validate can run to completion.

Also included is a fix for `action.yaml` which missed the runtime requirement for `node20`.