### PR TITLE
Use ${GITHUB_SHA} instead of HEAD to avoid race conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
       # Run breaking change detection against the `main` branch
       - uses: bufbuild/buf-breaking-action@v1
         with:
-          against: 'https://github.com/acme/weather.git#branch=main'
+          against: 'https://github.com/${GITHUB_REPOSITORY}.git#branch=main'
 ```
 
 With this configuration, the `buf` CLI detects breaking changes between the Protobuf sources in the
@@ -91,7 +91,7 @@ Detect breaking changes in a sub-directory | [`examples/detect-in-directory.yaml
 
 A common Buf workflow in GitHub Actions is to push the Protobuf sources in the current branch to the
 [Buf Schema Registry][bsr] if no breaking changes are detected against the previous commit (where
-`ref` is `HEAD~1`).
+`ref` is `${GITHUB_SHA}~1`).
 
 ```yaml
 on: # Apply to all pushes to `main`
@@ -108,7 +108,7 @@ jobs:
       # Run breaking change detection against the last commit
       - uses: bufbuild/buf-breaking-action@v1
         with:
-          against: 'https://github.com/acme/weather.git#branch=main,ref=HEAD~1'
+          against: 'https://github.com/${GITHUB_REPOSITORY}.git#branch=main,ref=${GITHUB_SHA}~1'
 ```
 
 ### Run against input in sub-directory
@@ -140,7 +140,7 @@ steps:
   - uses: bufbuild/buf-breaking-action@v1
     with:
       input: 'proto'
-      against: 'https://github.com/acme/weather.git#branch=main,ref=HEAD~1,subdir=proto'
+      against: 'https://github.com/${GITHUB_REPOSITORY}.git#branch=main,ref=${GITHUB_SHA}~1,subdir=proto'
 ```
 
 [actions]: https://docs.github.com/actions


### PR DESCRIPTION
Using HEAD exposes you to a race condition where if commits A and B are pushed in close succession, the breaking change check for A will not compare A with its previous commit (but instead compare B with A). Thus there would be no CI failure if commit A contains a breaking change, which is unfortunate.

Using ${GITHUB_SHA} protects against this race condition.

This approach still does not solve the problem where a single push may contain both of the commits, since GitHub Actions would only run the action on the last commit of the push. To solve that, you may want to get the first commit of the push using `${GITHUB_EVENT_PATH}`, which introduces extra complexity, so I don't think it's worth adding that to the README.

Misc change: changing to use `${GITHUB_REPOSITORY}` variable to make it more copy-paste friendly.